### PR TITLE
Add Using of the Child Logger for Modules and/or Classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ Here are some example calls. Use `logger.exception()` in an outer `except` block
         logger.exception(f"Error during calculation for batch_index={batch_index} uuid={uuid}")
 ```
 
+### Use Child Logger for Each Imported Class or Module
+
+When structuring a python application or a script in multiple modules (or classes), a `ChildLogger` for each
+module should be used.
+
+```python
+
+import logging
+
+class MyClass():
+  def __init__(self):
+    self.__logger = logging.getLogger(__name__).getChild('my_class')
+```
+
 ## Editor/IDE and code check
 
 * [PyCharm](https://www.jetbrains.com/pycharm/)

--- a/README.md
+++ b/README.md
@@ -40,19 +40,28 @@ Use [Python logging](https://docs.python.org/3/library/logging.html) instead of 
 ```python
 # Initialize logging
 import os, logging
+
 # Each log line includes the date and time, the log level, the current function and the message
 formatter = logging.Formatter('%(asctime)s %(levelname)-8s %(funcName)-30s %(message)s')
+
 # The log file is the same as the module name plus the suffix ".log"
 # i.e.: calculate.py -> calculate.py.log
 fh = logging.FileHandler("%s.log" % (os.path.basename(__file__)))
-sh = logging.StreamHandler()
 fh.setLevel(logging.DEBUG)      # set the log level for the log file
 fh.setFormatter(formatter)
+
+# Additionally, we want to display the current log output on stdout.
+# This can be archived using an additional stream handler.
+sh = logging.StreamHandler()
 sh.setFormatter(formatter)
 sh.setLevel(logging.INFO)       # set the log level for the console
+
 logger = logging.getLogger(__name__)
+
+# Add the Handler to the logger instance.
 logger.addHandler(fh)
 logger.addHandler(sh)
+
 logger.setLevel(logging.DEBUG)
 logger.propagate = False
 ```


### PR DESCRIPTION
The current example only uses one root logger for an entire python application. This is fine for a simple python script which does not uses multiple classes and/or modules.

However, when having a more structured application, which makes use of multiple modules, a child logger for each module should be used. One advantage for example is, that you can clearly see, which module produces which log message.